### PR TITLE
Fix no thumb file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site
 .sass-cache/
+.jekyll-cache/
 Gemfile.lock

--- a/blog.html
+++ b/blog.html
@@ -18,13 +18,16 @@ permalink: /blog/
           <p><csmall>{{ post.date | date: "%b %-d, %Y" }}. | By: {{ post.author }}</csmall></p>
         </div>
 
-        <div class="col-lg-9">
+        
+        <div class="{%if post.thumb%}col-lg-9{%else%}col-log-12{%endif%}">
           {{ post.excerpt }}
           <p><a href="{{ post.url | prepend: site.baseurl }}">[Read More]</a></p>
         </div>
-        <div class="col-lg-3">
-          <img class="img-responsive" src="{%if post.thumb contains 'http:' or post.thumb contains 'https:'%}{{post.thumb}}{%else%}{{"/assets/img/blog/"|prepend: site.baseurl}}{{post.thumb}}{%endif%}" />
-        </div>
+        {% if post.thumb %}
+          <div class="col-lg-3">
+             <img class="img-responsive" src="{%if post.thumb contains 'http:' or post.thumb contains 'https:'%}{{post.thumb}}{%else%}{{"/assets/img/blog/"|prepend: site.baseurl}}{{post.thumb}}{%endif%}" />
+          </div>
+        {% endif %}
       </div>
       <div class="hline"></div>
 


### PR DESCRIPTION
In [tune.moe/blog](tune.moe/blog) there are some blogs without thumb file, and their thumb files are rendered as `<img class="img-responsive" src="/assets/img/blog/">`, which can not be accessed.

In this Fix, the existence of thumb file is examined first. If it exists, it is rendered as before, otherwise thumb file is eliminated and the text takes the whole width of `col-lg-12`